### PR TITLE
Fix flaky HelpWindow clipboard test on macOS CI

### DIFF
--- a/dotnet/CspAnalyzer.Desktop.Tests/HelpWindowTests.cs
+++ b/dotnet/CspAnalyzer.Desktop.Tests/HelpWindowTests.cs
@@ -67,10 +67,28 @@ public class HelpWindowTests
             .Single(b => (string?)b.Content == "Copy");
         copyButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
 
-        string? clipboardText = await TopLevel.GetTopLevel(window)!.Clipboard!.GetTextAsync();
+        // HelpWindow's Click handler is `async void` - RaiseEvent doesn't wait
+        // for it, so reading the clipboard immediately races its SetTextAsync
+        // continuation. Usually wins locally; flaked intermittently on macOS
+        // CI runners. Poll briefly instead of asserting on the first read.
+        string? clipboardText = await PollClipboardTextAsync(window);
         Assert.Equal(
             "1 F1P 135; 2 F1P 11; 1 F2P 105; 2 F2P 6; MI 0.0001; PPNUM 90; pp2d nodia",
             clipboardText);
+    }
+
+    private static async Task<string?> PollClipboardTextAsync(HelpWindow window, int maxAttempts = 20, int delayMs = 10)
+    {
+        string? clipboardText = null;
+        for (int attempt = 0; attempt < maxAttempts && string.IsNullOrEmpty(clipboardText); attempt++)
+        {
+            clipboardText = await TopLevel.GetTopLevel(window)!.Clipboard!.GetTextAsync();
+            if (string.IsNullOrEmpty(clipboardText))
+            {
+                await Task.Delay(delayMs);
+            }
+        }
+        return clipboardText;
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary
- `HelpWindow.OnCopyClicked` is `async void`; `RaiseEvent(Button.ClickEvent)` in the test doesn't wait for its `SetTextAsync` continuation, so the test's immediate clipboard read races the write.
- Not CI noise: same test, same assertion, failed 2 of the last 4 CI runs on `macos-latest` specifically (seen while verifying the S14 packaging PR and again while cutting the v2.0.0 release).
- Fix is test-only: poll the clipboard for up to ~200ms instead of asserting on the first read. Production code (`HelpWindow.axaml.cs`) is untouched — `async void` there is normal/correct for a real UI click handler.

## Test plan
- [x] `dotnet test dotnet/CspAnalyzer.sln` — 168/168 passing locally