### PR TITLE
Add rpm packaging for the Linux release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -118,3 +120,50 @@ jobs:
         with:
           name: CspAnalyzer-${{ matrix.os-name }}-${{ matrix.rid }}
           path: artifacts/CspAnalyzer-${{ matrix.os-name }}-${{ matrix.rid }}.zip
+
+      - name: Install rpm build tools
+        if: matrix.os-name == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+          sudo gem install --no-document fpm
+
+      - name: Resolve rpm version
+        if: matrix.os-name == 'linux'
+        shell: bash
+        run: |
+          RAW_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0-dev")
+          # rpm's Version field can't contain "-" (reserved for the
+          # Version-Release separator) - replace with "." so a fallback
+          # "0.0.0-dev" or an annotated tag like "v2.0.1-rc1" both produce
+          # a valid rpm version string.
+          RPM_VERSION=$(echo "$RAW_VERSION" | sed 's/^v//' | tr '-' '.')
+          echo "RPM_VERSION=$RPM_VERSION" >> "$GITHUB_ENV"
+
+      - name: Build rpm package
+        if: matrix.os-name == 'linux'
+        shell: pwsh
+        run: ./scripts/package/package-rpm.ps1 -Version ${{ env.RPM_VERSION }}
+
+      - name: Verify rpm is well-formed
+        if: matrix.os-name == 'linux'
+        run: |
+          rpm -qlp artifacts/*.rpm
+          rpm -qip artifacts/*.rpm
+
+      - name: Verify rpm installs cleanly
+        if: matrix.os-name == 'linux'
+        run: |
+          docker run --rm -v ${{ github.workspace }}/artifacts:/artifacts rockylinux:9 bash -c "
+            rpm -i /artifacts/*.rpm &&
+            test -x /opt/csp-analyzer/CspAnalyzer.Desktop &&
+            test -x /usr/bin/csp-analyzer &&
+            test -f /usr/share/applications/csp-analyzer.desktop
+          "
+
+      - name: Upload rpm artifact
+        if: matrix.os-name == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: CspAnalyzer-linux-rpm
+          path: artifacts/*.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
       - name: Build rpm package
         if: matrix.os-name == 'linux'
         shell: pwsh
-        run: ./scripts/package/package-rpm.ps1 -Version ${{ env.RPM_VERSION }}
+        env:
+          RPM_VERSION: ${{ env.RPM_VERSION }}
+        run: ./scripts/package/package-rpm.ps1 -Version $env:RPM_VERSION
 
       - name: Verify rpm is well-formed
         if: matrix.os-name == 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         if: matrix.os-name == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm
+          sudo apt-get install -y rpm imagemagick
           sudo gem install --no-document fpm
 
       - name: Resolve rpm version
@@ -159,8 +159,10 @@ jobs:
           docker run --rm -v ${{ github.workspace }}/artifacts:/artifacts rockylinux:9 bash -c "
             rpm -i /artifacts/*.rpm &&
             test -x /opt/csp-analyzer/CspAnalyzer.Desktop &&
+            test -x /opt/csp-analyzer/csp-backend/csp-backend &&
             test -x /usr/bin/csp-analyzer &&
-            test -f /usr/share/applications/csp-analyzer.desktop
+            test -f /usr/share/applications/csp-analyzer.desktop &&
+            test -f /usr/share/icons/hicolor/256x256/apps/csp-analyzer.png
           "
 
       - name: Upload rpm artifact

--- a/docs/superpowers/specs/2026-07-25-rpm-packaging-design.md
+++ b/docs/superpowers/specs/2026-07-25-rpm-packaging-design.md
@@ -28,7 +28,7 @@ Runs after `package.ps1` has already assembled `artifacts/CspAnalyzer-linux-linu
   Categories=Science;Chemistry;
   Terminal=false
   ```
-- `/usr/share/icons/hicolor/256x256/apps/csp-analyzer.png` — converted from the existing `dotnet/CspAnalyzer.Desktop/Assets/cspanalyzer_SPd_icon.ico` via ImageMagick (`convert cspanalyzer_SPd_icon.ico[0] -resize 256x256 csp-analyzer.png`; `[0]` selects the largest frame in the multi-res `.ico`). `convert` is preinstalled on the `ubuntu-latest` GitHub-hosted runner image.
+- `/usr/share/icons/hicolor/256x256/apps/csp-analyzer.png` — converted from the existing `dotnet/CspAnalyzer.Desktop/Assets/cspanalyzer_SPd_icon.ico` via ImageMagick (`convert cspanalyzer_SPd_icon.ico -delete 0--2 -resize "256x256!" csp-analyzer.png`; frames in this `.ico` are stored smallest-first, so `-delete 0--2` drops every frame except the last (largest) one rather than relying on a hardcoded index). `imagemagick` (providing `convert`) is explicitly installed in the CI "Install rpm build tools" step rather than assumed present on the runner image.
 
 Then invokes `fpm`:
 ```

--- a/scripts/package/package-rpm.ps1
+++ b/scripts/package/package-rpm.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+  Wraps the already-assembled Linux package.ps1 output
+  (artifacts/CspAnalyzer-linux-linux-x64) into an rpm via fpm:
+  /opt/csp-analyzer install dir, /usr/bin wrapper, .desktop entry, icon.
+  Run from the repo root, after `package.ps1 -Rid linux-x64 -OsName linux`
+  has already produced its output (the CI package job's linux-x64 leg runs
+  both - see .github/workflows/ci.yml's `package` job). Linux-only: fpm,
+  rpmbuild, and convert are Linux tools, so this script is only ever
+  invoked on the ubuntu-latest runner leg, never windows/macos.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$Version   # e.g. 2.0.1 or 0.0.0.dev - no leading "v", no "-"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$assembledDir = Join-Path $repoRoot "artifacts/CspAnalyzer-linux-linux-x64"
+$iconIco = Join-Path $repoRoot "dotnet/CspAnalyzer.Desktop/Assets/cspanalyzer_SPd_icon.ico"
+$artifactsDir = Join-Path $repoRoot "artifacts"
+$stagingDir = Join-Path $artifactsDir "rpm-staging"
+$rpmPath = Join-Path $artifactsDir "csp-analyzer-$Version.x86_64.rpm"
+
+if (-not (Test-Path $assembledDir)) {
+    throw "Assembled package not found at $assembledDir - run 'package.ps1 -Rid linux-x64 -OsName linux' first."
+}
+if (-not (Test-Path $iconIco)) {
+    throw "Icon not found at $iconIco."
+}
+foreach ($tool in @("fpm", "convert", "rpmbuild")) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        throw "$tool not found on PATH - required to build the rpm."
+    }
+}
+
+if (Test-Path $stagingDir) {
+    Remove-Item -Recurse -Force $stagingDir
+}
+
+$optDir = Join-Path $stagingDir "opt/csp-analyzer"
+$binDir = Join-Path $stagingDir "usr/bin"
+$appsDir = Join-Path $stagingDir "usr/share/applications"
+$iconDir = Join-Path $stagingDir "usr/share/icons/hicolor/256x256/apps"
+New-Item -ItemType Directory -Force -Path $optDir, $binDir, $appsDir, $iconDir | Out-Null
+
+Copy-Item -Path "$assembledDir/*" -Destination $optDir -Recurse -Force
+
+$wrapperPath = Join-Path $binDir "csp-analyzer"
+Set-Content -Path $wrapperPath -Value @'
+#!/bin/sh
+exec /opt/csp-analyzer/CspAnalyzer.Desktop "$@"
+'@
+chmod +x $wrapperPath
+
+$desktopPath = Join-Path $appsDir "csp-analyzer.desktop"
+Set-Content -Path $desktopPath -Value @'
+[Desktop Entry]
+Type=Application
+Name=CSP Analyzer
+Exec=csp-analyzer
+Icon=csp-analyzer
+Categories=Science;Chemistry;
+Terminal=false
+'@
+
+$iconPngPath = Join-Path $iconDir "csp-analyzer.png"
+# "${iconIco}[0]" (curly braces) rather than "$iconIco[0]" - the latter is
+# parsed by PowerShell as string-indexing inside a double-quoted string.
+# The "[0]" here is ImageMagick's own frame-select syntax, picking the
+# largest frame out of the multi-resolution .ico.
+& convert "${iconIco}[0]" -resize 256x256 $iconPngPath
+if ($LASTEXITCODE -ne 0) {
+    throw "convert exited with code $LASTEXITCODE"
+}
+
+if (Test-Path $rpmPath) {
+    Remove-Item $rpmPath
+}
+
+& fpm -s dir -t rpm `
+    -n csp-analyzer -v $Version -a x86_64 `
+    --license MIT `
+    --description "CSP-Analyzer: NMR chemical shift perturbation analysis" `
+    --url "https://github.com/rubbs14/CSP-Analyzer" `
+    -p $rpmPath `
+    -C $stagingDir opt usr
+if ($LASTEXITCODE -ne 0) {
+    throw "fpm exited with code $LASTEXITCODE"
+}
+
+Write-Host "Packaged: $rpmPath"

--- a/scripts/package/package-rpm.ps1
+++ b/scripts/package/package-rpm.ps1
@@ -46,6 +46,18 @@ New-Item -ItemType Directory -Force -Path $optDir, $binDir, $appsDir, $iconDir |
 
 Copy-Item -Path "$assembledDir/*" -Destination $optDir -Recurse -Force
 
+# Defensively re-assert executable bits on the binaries, since Copy-Item on
+# PowerShell Core may not reliably preserve Unix permission bits (precedent in package.ps1).
+$executablesToMarkRunnable = @(
+    (Join-Path $optDir "CspAnalyzer.Desktop"),
+    (Join-Path $optDir "csp-backend" "csp-backend")
+)
+foreach ($executablePath in $executablesToMarkRunnable) {
+    if (Test-Path $executablePath) {
+        chmod +x $executablePath
+    }
+}
+
 $wrapperPath = Join-Path $binDir "csp-analyzer"
 Set-Content -Path $wrapperPath -Value @'
 #!/bin/sh

--- a/scripts/package/package-rpm.ps1
+++ b/scripts/package/package-rpm.ps1
@@ -77,11 +77,12 @@ Terminal=false
 '@
 
 $iconPngPath = Join-Path $iconDir "csp-analyzer.png"
-# "${iconIco}[0]" (curly braces) rather than "$iconIco[0]" - the latter is
-# parsed by PowerShell as string-indexing inside a double-quoted string.
-# The "[0]" here is ImageMagick's own frame-select syntax, picking the
-# largest frame out of the multi-resolution .ico.
-& convert "${iconIco}[0]" -resize 256x256 $iconPngPath
+# Frames are stored smallest-first in this .ico; "-delete 0--2" drops all
+# but the last (largest) frame, then "!" forces an exact 256x256 output
+# regardless of the source frame's exact aspect ratio. "${iconIco}" (curly
+# braces) rather than "$iconIco" avoids PowerShell parsing "[...]" as
+# string-indexing inside the double-quoted string that follows.
+& convert "${iconIco}" -delete 0--2 -resize "256x256!" $iconPngPath
 if ($LASTEXITCODE -ne 0) {
     throw "convert exited with code $LASTEXITCODE"
 }


### PR DESCRIPTION
## Summary
- New `scripts/package/package-rpm.ps1` wraps the existing Linux zip-packaging output into an rpm via `fpm`: `/opt/csp-analyzer` install dir, `/usr/bin/csp-analyzer` wrapper, `.desktop` entry, and a converted icon.
- `.github/workflows/ci.yml`'s `package` job gains new steps (linux-x64 leg only) that install `fpm`/`rpmbuild`/imagemagick, resolve a version from the latest git tag, build the rpm, verify it's well-formed, actually install it inside a `rockylinux:9` container, and upload it as a separate `CspAnalyzer-linux-rpm` artifact — additive to the existing zip, nothing replaced.
- Fixed a script-injection pattern in the CI step during review (version now passed via `env:` block, not spliced into the shell command text) and a bug where the app icon would have shipped badly upscaled from a 16x16 source frame instead of the bundled 256x256 one.

Design: `docs/superpowers/specs/2026-07-25-rpm-packaging-design.md`
Plan: `docs/superpowers/plans/2026-07-25-rpm-packaging.md`

## Test plan
- [x] `dotnet test dotnet/CspAnalyzer.sln` — 169/169 passing (unaffected by this change, run as a regression check)
- [x] `pytest backend/tests` — 35/35 passing (unaffected by this change, run as a regression check)
- [ ] Trigger the `package` workflow (`workflow_dispatch`) on this branch and confirm the linux-x64 leg's new steps succeed and `CspAnalyzer-linux-rpm` appears as a downloadable artifact — no local `pwsh`/`fpm`/`rpm`/`docker` available to verify this any other way

🤖 Generated with [Claude Code](https://claude.com/claude-code)