### PR TITLE
Add Windows installer packaging (Inno Setup, per-user install)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
         run: |
           $rawVersion = git describe --tags --abbrev=0 2>$null
           if (-not $rawVersion) { $rawVersion = "v0.0.0-dev" }
+          $global:LASTEXITCODE = 0
           $installerVersion = $rawVersion -replace '^v', '' -replace '-', '.'
           "INSTALLER_VERSION=$installerVersion" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
@@ -144,7 +145,8 @@ jobs:
           INSTALLER_VERSION: ${{ env.INSTALLER_VERSION }}
         run: |
           $installerPath = "artifacts\CspAnalyzer-Setup-$env:INSTALLER_VERSION.exe"
-          Start-Process -FilePath $installerPath -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART" -Wait
+          $process = Start-Process -FilePath $installerPath -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART" -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "installer exited with code $($process.ExitCode)" }
 
           $installDir = Join-Path $env:LOCALAPPDATA "CspAnalyzer"
           if (-not (Test-Path (Join-Path $installDir "CspAnalyzer.Desktop.exe"))) {
@@ -187,7 +189,7 @@ jobs:
           }
 
       - name: Upload installer artifact
-        if: matrix.os-name == 'windows'
+        if: always() && matrix.os-name == 'windows'
         uses: actions/upload-artifact@v4
         with:
           name: CspAnalyzer-windows-installer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -118,3 +120,75 @@ jobs:
         with:
           name: CspAnalyzer-${{ matrix.os-name }}-${{ matrix.rid }}
           path: artifacts/CspAnalyzer-${{ matrix.os-name }}-${{ matrix.rid }}.zip
+
+      - name: Resolve installer version
+        if: matrix.os-name == 'windows'
+        shell: pwsh
+        run: |
+          $rawVersion = git describe --tags --abbrev=0 2>$null
+          if (-not $rawVersion) { $rawVersion = "v0.0.0-dev" }
+          $installerVersion = $rawVersion -replace '^v', '' -replace '-', '.'
+          "INSTALLER_VERSION=$installerVersion" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Build Windows installer
+        if: matrix.os-name == 'windows'
+        shell: pwsh
+        env:
+          INSTALLER_VERSION: ${{ env.INSTALLER_VERSION }}
+        run: ./scripts/package/package-installer.ps1 -Version $env:INSTALLER_VERSION
+
+      - name: Verify installer installs cleanly
+        if: matrix.os-name == 'windows'
+        shell: pwsh
+        env:
+          INSTALLER_VERSION: ${{ env.INSTALLER_VERSION }}
+        run: |
+          $installerPath = "artifacts\CspAnalyzer-Setup-$env:INSTALLER_VERSION.exe"
+          Start-Process -FilePath $installerPath -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART" -Wait
+
+          $installDir = Join-Path $env:LOCALAPPDATA "CspAnalyzer"
+          if (-not (Test-Path (Join-Path $installDir "CspAnalyzer.Desktop.exe"))) {
+              throw "app exe missing after install"
+          }
+          if (-not (Test-Path (Join-Path $installDir "csp-backend\csp-backend.exe"))) {
+              throw "backend exe missing after install"
+          }
+          $shortcut = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\CSP Analyzer\CSP Analyzer.lnk"
+          if (-not (Test-Path $shortcut)) {
+              throw "Start Menu shortcut missing after install"
+          }
+          $uninstallKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{D6B0EA6C-E5EC-4259-B860-3D199A86A829}_is1"
+          if (-not (Test-Path $uninstallKey)) {
+              throw "uninstall registry key missing after install"
+          }
+
+      - name: Verify installer uninstalls cleanly
+        if: matrix.os-name == 'windows'
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:LOCALAPPDATA "CspAnalyzer"
+          $uninstaller = Join-Path $installDir "unins000.exe"
+          Start-Process -FilePath $uninstaller -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES" -Wait
+
+          # Inno's uninstaller copies itself to %TEMP% and relaunches so it
+          # can delete its own running exe - the original process (the one
+          # -Wait blocks on) can exit before that copy finishes deleting
+          # $installDir. Poll instead of trusting -Wait alone.
+          $deadline = (Get-Date).AddSeconds(30)
+          while ((Test-Path $installDir) -and (Get-Date) -lt $deadline) {
+              Start-Sleep -Seconds 1
+          }
+          if (Test-Path $installDir) {
+              throw "install dir still present after uninstall (timed out waiting)"
+          }
+          $uninstallKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\{D6B0EA6C-E5EC-4259-B860-3D199A86A829}_is1"
+          if (Test-Path $uninstallKey) {
+              throw "uninstall registry key still present after uninstall"
+          }
+
+      - name: Upload installer artifact
+        if: matrix.os-name == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: CspAnalyzer-windows-installer
+          path: artifacts/CspAnalyzer-Setup-*.exe

--- a/docs/superpowers/specs/2026-07-25-windows-installer-design.md
+++ b/docs/superpowers/specs/2026-07-25-windows-installer-design.md
@@ -16,7 +16,7 @@ Runs after `package.ps1` has already assembled `artifacts/CspAnalyzer-windows-wi
   - `DefaultDirName={localappdata}\CspAnalyzer` (per-user install location)
   - `DefaultGroupName=CSP Analyzer` (Start Menu folder)
   - `OutputDir=artifacts`, `OutputBaseFilename=CspAnalyzer-Setup-<Version>`
-  - `SetupIconFile` and shortcut icon both point at the existing `dotnet/CspAnalyzer.Desktop/Assets/cspanalyzer_SPd_icon.ico` — used directly, no format conversion needed (unlike the rpm work, which had to convert `.ico` → `.png` for freedesktop icon theming)
+  - `SetupIconFile` (compile-time only) points at the existing `dotnet/CspAnalyzer.Desktop/Assets/cspanalyzer_SPd_icon.ico` directly, no format conversion needed (unlike the rpm work, which had to convert `.ico` → `.png` for freedesktop icon theming). The `[Icons]` Start Menu shortcut has no `IconFilename` and instead relies on the icon already embedded in `CspAnalyzer.Desktop.exe` via the `.csproj`'s `<ApplicationIcon>` — `IconFilename` on an `[Icons]` entry resolves on the end user's machine, where a build-machine `.ico` path wouldn't exist.
   - `[Files]` section: bundles the entire `artifacts/CspAnalyzer-windows-win-x64/` tree verbatim (recursive, `Flags: recursesubdirs`) into `{app}`
   - `[Icons]` section: one Start Menu shortcut, `{group}\CSP Analyzer.lnk` → `{app}\CspAnalyzer.Desktop.exe`
   - Uninstaller is automatic (Inno Setup always generates `unins000.exe` + a `HKCU\...\Uninstall\{AppId}_is1` registry entry when `PrivilegesRequired=lowest`)

--- a/scripts/package/package-installer.ps1
+++ b/scripts/package/package-installer.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+  Wraps the already-assembled Windows package.ps1 output
+  (artifacts/CspAnalyzer-windows-win-x64) into a per-user Inno Setup
+  installer. Run from the repo root, after
+  `package.ps1 -Rid win-x64 -OsName windows` has already produced its
+  output (the CI package job's windows-x64 leg runs both - see
+  .github/workflows/ci.yml's `package` job). Windows-only: iscc.exe is a
+  Windows tool, so this script is only ever invoked on the windows-latest
+  runner leg, never linux/macos.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$Version   # e.g. 2.0.1 or 0.0.0.dev - no leading "v", no "-"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$assembledDir = Join-Path $repoRoot "artifacts/CspAnalyzer-windows-win-x64"
+$iconIco = Join-Path $repoRoot "dotnet/CspAnalyzer.Desktop/Assets/cspanalyzer_SPd_icon.ico"
+$artifactsDir = Join-Path $repoRoot "artifacts"
+$stagingDir = Join-Path $artifactsDir "installer-staging"
+$issPath = Join-Path $stagingDir "CspAnalyzer.iss"
+$installerPath = Join-Path $artifactsDir "CspAnalyzer-Setup-$Version.exe"
+
+if (-not (Test-Path $assembledDir)) {
+    throw "Assembled package not found at $assembledDir - run 'package.ps1 -Rid win-x64 -OsName windows' first."
+}
+if (-not (Test-Path $iconIco)) {
+    throw "Icon not found at $iconIco."
+}
+if (-not (Get-Command "iscc" -ErrorAction SilentlyContinue)) {
+    throw "iscc (Inno Setup compiler) not found on PATH - required to build the installer."
+}
+
+if (Test-Path $stagingDir) {
+    Remove-Item -Recurse -Force $stagingDir
+}
+New-Item -ItemType Directory -Force -Path $stagingDir | Out-Null
+
+# AppId's "{{...}" is Inno Setup's own escape for a literal "{" - it
+# renders as "{GUID}" in the compiled installer. Fixed GUID so every
+# version's installer/uninstaller targets the same Uninstall registry
+# entry (upgrades replace in place instead of leaving two entries).
+$issContent = @"
+[Setup]
+AppId={{D6B0EA6C-E5EC-4259-B860-3D199A86A829}
+AppName=CSP Analyzer
+AppVersion=$Version
+DefaultDirName={localappdata}\CspAnalyzer
+DefaultGroupName=CSP Analyzer
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+OutputDir=$artifactsDir
+OutputBaseFilename=CspAnalyzer-Setup-$Version
+SetupIconFile=$iconIco
+Compression=lzma
+SolidCompression=yes
+
+[Files]
+Source: "$assembledDir\*"; DestDir: "{app}"; Flags: recursesubdirs
+
+[Icons]
+Name: "{group}\CSP Analyzer"; Filename: "{app}\CspAnalyzer.Desktop.exe"; IconFilename: "$iconIco"
+"@
+
+Set-Content -Path $issPath -Value $issContent
+
+if (Test-Path $installerPath) {
+    Remove-Item $installerPath
+}
+
+& iscc $issPath
+if ($LASTEXITCODE -ne 0) {
+    throw "iscc exited with code $LASTEXITCODE"
+}
+
+Write-Host "Packaged: $installerPath"

--- a/scripts/package/package-installer.ps1
+++ b/scripts/package/package-installer.ps1
@@ -51,17 +51,19 @@ DefaultDirName={localappdata}\CspAnalyzer
 DefaultGroupName=CSP Analyzer
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
-OutputDir=$artifactsDir
+OutputDir="$artifactsDir"
 OutputBaseFilename=CspAnalyzer-Setup-$Version
-SetupIconFile=$iconIco
-Compression=lzma
+SetupIconFile="$iconIco"
+UninstallDisplayIcon={app}\CspAnalyzer.Desktop.exe
+ArchitecturesAllowed=x64compatible
+Compression=lzma2
 SolidCompression=yes
 
 [Files]
-Source: "$assembledDir\*"; DestDir: "{app}"; Flags: recursesubdirs
+Source: "$assembledDir\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Icons]
-Name: "{group}\CSP Analyzer"; Filename: "{app}\CspAnalyzer.Desktop.exe"; IconFilename: "$iconIco"
+Name: "{group}\CSP Analyzer"; Filename: "{app}\CspAnalyzer.Desktop.exe"
 "@
 
 Set-Content -Path $issPath -Value $issContent


### PR DESCRIPTION
## Summary
- New `scripts/package/package-installer.ps1` wraps the existing `package.ps1` Windows output into a per-user Inno Setup installer (no UAC, fixed AppId for stable upgrades).
- CI's `package` job gains windows-gated steps: resolve version from git tag, build the installer, silent-install + verify (app exe, backend exe, Start Menu shortcut, uninstall registry key), silent-uninstall + verify cleanup, upload as `CspAnalyzer-windows-installer`.
- Additive only — existing Windows zip artifact is untouched.

Went through spec → plan → subagent-driven implementation → per-task review → final whole-branch review. The final review caught two real defects invisible to CI by construction (both fixed): a Start Menu shortcut pointing at a build-machine-only icon path, and a missing `ignoreversion` flag that would have let upgrades silently keep stale app binaries. Also fixed a version-resolution fallback that wouldn't have actually saved the build on a tagless repo, plus several hardening minors (lzma2 compression, UninstallDisplayIcon, ArchitecturesAllowed, installer exit-code capture, unconditional artifact upload for post-mortem).

## Test plan
- [x] Real `workflow_dispatch` CI run on this branch: https://github.com/rubbs14/CSP-Analyzer/actions/runs/30153188806 — all jobs green, including the new install/uninstall verification steps on `windows-latest`.
- [x] `CspAnalyzer-windows-installer` artifact produced alongside the existing zip artifacts.
- [x] Full `python-tests`/`dotnet-tests` suites passed on all 3 OS in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)